### PR TITLE
Remove mongodb credentials from this file

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -1,3 +1,3 @@
 {
-  "DATABASE_URI": "mongodb+srv://akashdutta93:qmCBSVRMFyX5T25E@cluster0.spyim.mongodb.net/note-app?retryWrites=true&w=majority"
+  "DATABASE_URI": ""
 }


### PR DESCRIPTION
The production credentials are in this file please remove the mongodb credentials. Or set this repository to private.

I did a test to connect and list the databases:
```
Connected to mongo server.
Databases:
 - note-app
 - admin
 - local
```

Remember when removing the credentials please make sure you clear the commit history:
https://stackoverflow.com/questions/13716658/how-to-delete-all-commit-history-in-github